### PR TITLE
ci(github): add remove docker tag

### DIFF
--- a/.github/workflows/staging-docker.yml
+++ b/.github/workflows/staging-docker.yml
@@ -68,6 +68,16 @@ jobs:
           url-prefix: pr-${{ env.PR_NUMBER }}
           env: ${{ env.ENV }}
           app: ${{ env.APP }}
+      
+      - name: Remove Docker Tag
+        if: github.event_name == 'pull_request' && github.event.action == 'closed'
+        uses: aeternity/ae-github-actions/remove-docker-tag@v2
+        with:
+          tag: pr-${{ env.PR_NUMBER }}
+          organization: aeternity
+          image: dex-ui
+          dockerhub_user: ${{ secrets.DOCKERHUB_USER }}
+          dockerhub_pass: ${{ secrets.DOCKERHUB_PASS }}
 
       - name: Print PR url
         uses: unsplash/comment-on-pr@v1.3.0


### PR DESCRIPTION
Remove docker tag on undeploy in staging
Its blocked by Dincho opinion that we don't want to give the bot permissions to delete tags in dockerhub.We will discuss it again.