### PR TITLE
 ci(github): change branch to stg

### DIFF
--- a/.github/workflows/staging-docker.yml
+++ b/.github/workflows/staging-docker.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: aeternity/gitops-apps.git
-          ref: staging
+          ref: stg
           persist-credentials: false
           fetch-depth: 0
 
@@ -83,4 +83,4 @@ jobs:
         with:
           repository: aeternity/gitops-apps
           github_token: ${{ secrets.BOT_GITHUB_TOKEN }}
-          branch: staging
+          branch: stg


### PR DESCRIPTION
Change branch due to redeploy of the eks cluster.