### PR TITLE
fix: propagate update event to InputToken's parent

### DIFF
--- a/src/components/InputToken.vue
+++ b/src/components/InputToken.vue
@@ -13,6 +13,7 @@
         v-bind="$attrs"
         type="number"
         placeholder="0.0"
+        @update:value="$emit('update:value', $event)"
       />
     </div>
     <div


### PR DESCRIPTION
The InputToken does not fire `update:event` to it's parent