### PR TITLE
fix: do not close active connection with iframe wallet

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -43,7 +43,7 @@
       </ActionsMenu>
     </div>
     <iframe
-      v-if="useIframeWallet && !address"
+      v-if="useIframeWallet"
       :src="walletUrl"
     />
   </div>


### PR DESCRIPTION
previous `v-if` condition was droping iframe element