### PR TITLE
fix(index): do not scan for wallets if already connected

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -106,6 +106,7 @@ export default createStore({
       commit('setConnectingToWallet', false);
     },
     async scanForWallets({ commit, dispatch, state: { sdk } }) {
+      if (sdk.rpcClient) return null;
       const scannerConnection = await BrowserWindowMessageConnection({
         connectionInfo: { id: 'spy' },
       });


### PR DESCRIPTION
problem: if you manual connect fast enough, it will scan for wallets one more time resulting in error.
![image](https://user-images.githubusercontent.com/9008074/160411274-2e7aea93-5460-4a64-b2a5-92230358a1ec.png)
