### PR TITLE
fix(swap-view): swap button is enabled when there is no pair/route

### DIFF
--- a/src/views/SwapView.vue
+++ b/src/views/SwapView.vue
@@ -135,7 +135,8 @@ export default {
       return !!this.selectedRoute;
     },
     isDisabled() {
-      return !this.tokenB || !this.tokenA || !this.isValidAmount || !this.enoughBalance;
+      return !this.tokenB || !this.tokenA || !this.isValidAmount
+             || !this.enoughBalance || (!this.hasRoute && !this.isAeVsWae);
     },
     enoughAllowance() {
       if (!this.tokenA) return false;


### PR DESCRIPTION
Fixes #337 

@Liubov-crypto The issue was reproducing only when `dex-backend` is disabled and only if you follow the steps described in the issue details 