### PR TITLE
fix(pool-view): filter provided liquidity by active network

### DIFF
--- a/src/store/modules/aeternity.js
+++ b/src/store/modules/aeternity.js
@@ -127,6 +127,7 @@ export default {
       tokenADecimals, tokenBDecimals,
       balance,
       address,
+      networkId,
     }) {
       const [token0, token1] = sortTokens(
         { cid: tokenA, symbol: tokenASymbol, decimals: tokenADecimals },
@@ -137,7 +138,10 @@ export default {
         state.providedLiquidity[address] = {};
       }
       state.providedLiquidity[address][getPairId(tokenA, tokenB)] = balance ? {
-        token0, token1, balanceStr: balance.toString(),
+        token0,
+        token1,
+        balanceStr: balance.toString(),
+        networkId,
       } : undefined;
     },
     updatePoolInfo(state, {
@@ -276,11 +280,13 @@ export default {
       dispatch,
       commit,
       rootState: { address },
+      rootGetters: { activeNetwork },
     }, {
       tokenA, tokenB,
       tokenASymbol, tokenBSymbol,
       tokenADecimals, tokenBDecimals,
     }) {
+      if (!activeNetwork) return null;
       const pair = await dispatch('getPairByTokens', { tokenA, tokenB });
 
       const { decodedResult: balance } = await pair.methods.balance(address);
@@ -293,6 +299,7 @@ export default {
         tokenADecimals,
         tokenBDecimals,
         address,
+        networkId: activeNetwork.networkId,
       });
       return balance;
     },

--- a/src/views/PoolView.vue
+++ b/src/views/PoolView.vue
@@ -59,7 +59,7 @@ export default {
       ).map((key) => ({
         id: key,
         payload: state.aeternity.providedLiquidity[state.address][key],
-      })).filter((x) => x.payload),
+      })).filter((x) => x.payload?.networkId === state.networkId),
     }),
   },
   methods: {


### PR DESCRIPTION
Fixes #371 

How to test:

1) Import some liquidity you own on testnet
2) Do the same in mainnet  (if you don't have liquidity or tokens on mainnet, ping @bogdan-manole )
3) Switch between networks and see how the pool list is changing based on what network you have selected

![network specific pools](https://user-images.githubusercontent.com/3176255/177843761-6cb549d6-482d-448a-bc45-22f6e0088dd6.gif)

